### PR TITLE
add a route for enums

### DIFF
--- a/src/api/app.js
+++ b/src/api/app.js
@@ -49,7 +49,6 @@ app.use('/readyz', health.ReadinessEndpoint(healthcheck));
 const { schemas } = apiDocument.components;
 app.use('/docs/api', swaggerUi.serve, swaggerUi.setup(apiDocument));
 app.get('/docs/specs', (req, res) => { res.status(200).json(apiDocument); });
-app.get('/docs/schemas', (req, res) => { res.status(200).json(schemas); });
 app.get('/docs/enums', (req, res) => {
   res.status(200).json(
     Object.fromEntries(Object.entries(schemas).filter(([key]) => key.match(/Enum$/))),

--- a/src/api/app.js
+++ b/src/api/app.js
@@ -46,8 +46,15 @@ app.use('/livez', health.LivenessEndpoint(healthcheck));
 app.use('/readyz', health.ReadinessEndpoint(healthcheck));
 
 // Expose swagger API documentation
+const { schemas } = apiDocument.components;
 app.use('/docs/api', swaggerUi.serve, swaggerUi.setup(apiDocument));
-app.get('/docs/api-specs.yml', (req, res) => { res.send(apiDocument); });
+app.get('/docs/specs', (req, res) => { res.status(200).json(apiDocument); });
+app.get('/docs/schemas', (req, res) => { res.status(200).json(schemas); });
+app.get('/docs/enums', (req, res) => {
+  res.status(200).json(
+    Object.fromEntries(Object.entries(schemas).filter(([key]) => key.match(/Enum$/))),
+  );
+});
 
 // express-openapi-validator setup to validate requests
 app.use(OAV.middleware({

--- a/src/openapi/schemas/documents/document-payload.yml
+++ b/src/openapi/schemas/documents/document-payload.yml
@@ -4,7 +4,7 @@ type: object
 properties:
   documentTypeId:
     type: string
-    pattern: ^[a-zA-Z0-9]{5}$
+    pattern: ^[a-zA-Z0-9]{15}$
     description: Un identifiant de type de document
   title:
     type: string


### PR DESCRIPTION
Calling /docs/enums returns an object with all enums schemas in the openAPI documentation.